### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@release-it/conventional-changelog": "^10.0.2",
     "@swc-node/register": "1.10.9",
     "@swc/cli": "0.6.0",
-    "@types/google-libphonenumber": "^7.4.30",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.19.0",
     "@types/react": "19.1.8",
@@ -120,6 +119,7 @@
   "registry": "https://registry.npmjs.org/",
   "dependencies": {
     "@payloadcms/translations": "^3.0.0",
+    "@types/google-libphonenumber": "^7.4.30",
     "clsx": "^2.1.1",
     "google-libphonenumber": "^3.2.43"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@payloadcms/translations':
         specifier: ^3.0.0
         version: 3.62.1
+      '@types/google-libphonenumber':
+        specifier: ^7.4.30
+        version: 7.4.30
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -54,9 +57,6 @@ importers:
       '@swc/cli':
         specifier: 0.6.0
         version: 0.6.0(@swc/core@1.15.0)(chokidar@4.0.3)
-      '@types/google-libphonenumber':
-        specifier: ^7.4.30
-        version: 7.4.30
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15


### PR DESCRIPTION
Be compatible with more payload versions.
Include @types/google-libphonenumber as dependency to include the proper types for RegionCode for package users.